### PR TITLE
Add submodule folder to fix `git submodule init`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/sjcl"]
-	path = external/sjcl
-	url = https://github.com/bitwiseshiftleft/sjcl.git

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "performance-now": "^2.1.0",
     "pg": "^7.1.2",
     "sendmail": "^1.2.0",
-    "sjcl": "git+https://github.com/bitwiseshiftleft/sjcl.git",
+    "sjcl": "latest",
     "validator": "^8.0.0",
     "vinyl-source-stream": "^1.1.0",
     "webcrypto": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "async": "latest",
+    "nan": "^2.6.2",
     "base64url": "^2.0.0",
     "bindings": "^1.3.0",
     "body-parser": "^1.17.2",
@@ -35,7 +36,6 @@
     "json3": "latest",
     "minimist": "^1.2.0",
     "multer": "^1.3.0",
-    "nan": "^2.6.2",
     "node-glob": "^1.2.0",
     "node-gyp": "^3.6.2",
     "performance-now": "^2.1.0",

--- a/src/common/Elliptic.js
+++ b/src/common/Elliptic.js
@@ -1,4 +1,4 @@
-const sjcl = require("./sjcl");
+const sjcl = require("sjcl");
 const POINT_COMPRESSED = 2;
 const POINT_COMPRESSED_ODD = 3;
 const POINT_UNCOMPRESSED = 4;

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -4,4 +4,4 @@
 exports.Elliptic = require("./Elliptic");
 exports.parameter = require('./parameter');
 exports.PKI = require("./PKI");
-exports.sjcl = require("./sjcl");
+exports.sjcl = require("sjcl");

--- a/src/common/sjcl.js
+++ b/src/common/sjcl.js
@@ -1,1 +1,0 @@
-../../external/sjcl/sjcl.js


### PR DESCRIPTION
Currently the instructions in the readme do not work, forcing users to manually create the folder and add the submodule

This change makes the instructions in the README work